### PR TITLE
Fix: "error: ‘errno’ undeclared"

### DIFF
--- a/src/buttermilk.c
+++ b/src/buttermilk.c
@@ -2,6 +2,7 @@
 #include "buttermilk.h"
 #include "colors.h"
 #include "config.h"
+#include <errno.h>
 
 #define SIZE_COLUMNS    100
 #define SIZE_ROWS       40


### PR DESCRIPTION
Could be a typo in the `src/buttermilk.h`, but here on my machine GCC complains regarding `errno.h` not included in buttermilk.c when built using `make` command.